### PR TITLE
Removes throw error if WorkSheetName is too long

### DIFF
--- a/PSExcel/Add-Table.ps1
+++ b/PSExcel/Add-Table.ps1
@@ -98,7 +98,8 @@ function Add-Table {
         [parameter( Position = 1,
                     Mandatory=$false,
                     ValueFromPipeline=$false,
-                    ValueFromPipelineByPropertyName=$false)]
+                    ValueFromPipelineByPropertyName=$false)
+                    ValidateLength(1,31)]
         [string]$WorkSheetName,
 
         [parameter(


### PR DESCRIPTION
Aded ValidateLength(1,31) to WorkSheetName to stop throw error